### PR TITLE
added null check to dispose() method

### DIFF
--- a/pvmanager-extra/src/main/java/org/epics/pvmanager/formula/PvFormulaFunction.java
+++ b/pvmanager-extra/src/main/java/org/epics/pvmanager/formula/PvFormulaFunction.java
@@ -86,7 +86,9 @@ class PvFormulaFunction extends DynamicFormulaFunction {
     @Override
     public void dispose() {
         // Disconnect everything on dispose
-        getDirector().disconnectReadExpression(currentExpression);
+        if (currentExpression != null) {
+            getDirector().disconnectReadExpression(currentExpression);
+        }
         currentExpression = null;
     }
     


### PR DESCRIPTION
When I introduced errors into PV formulas in OPIs, I saw a large number of NullPointer exceptions raised by PVFormulaFunction when the dispose() method was called. 
This was seen in the pvmanager version in DLS fork of CSS, which was last merged from cs-studio/master on 14-Oct.

I have added a null check (c.f. the check in connect()) which fixes this issue.
This patch has been updated to use the revised director API ( disconnectReadExpression() )
